### PR TITLE
Add Organization-Based Role Sync with Manual Category Control

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,206 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/*
+Crucible Applications Landing Page Block for Moodle
+
+Copyright 2024 Carnegie Mellon University.
+
+NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO,
+WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL.
+CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+Licensed under a GNU GENERAL PUBLIC LICENSE - Version 3, 29 June 2007-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+
+[DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution. Please see Copyright notice for non-US Government use and distribution.
+
+This Software includes and/or makes use of Third-Party Software each subject to its own license.
+
+DM24-1176
+*/
+
+namespace block_crucible;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Event observer for block_crucible.
+ *
+ * @package    block_crucible
+ * @copyright  2024 Carnegie Mellon University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class observer {
+
+    /**
+     * Triggered when a user logs in.
+     * Syncs the user's organization roles if they have ssoorg and ssogroups data.
+     *
+     * @param \core\event\user_loggedin $event
+     */
+    public static function user_loggedin(\core\event\user_loggedin $event) {
+        global $DB, $CFG;
+
+        // Check if org role sync is enabled.
+        if (!get_config('block_crucible', 'enableorgrolesync')) {
+            return;
+        }
+
+        // Only proceed if the user logged in via OAuth2.
+        $userid = $event->userid;
+        $user = $DB->get_record('user', ['id' => $userid], '*', IGNORE_MISSING);
+
+        if (!$user || $user->auth !== 'oauth2') {
+            return;
+        }
+
+        // Check if user has ssoorg and ssogroups profile data.
+        require_once($CFG->dirroot . '/user/profile/lib.php');
+        profile_load_data($user);
+
+        $ssoorg = isset($user->profile_field_ssoorg) ? trim($user->profile_field_ssoorg) : '';
+        $ssogroups = isset($user->profile_field_ssogroups) ? trim($user->profile_field_ssogroups) : '';
+
+        if (empty($ssoorg) || empty($ssogroups)) {
+            // User doesn't have required profile data, nothing to sync.
+            return;
+        }
+
+        // Throttle: only sync if not synced in the last 5 minutes to avoid hammering on multiple logins.
+        $cachekey = 'org_role_sync_' . $userid;
+        $cache = \cache::make('block_crucible', 'org_role_sync');
+        $lastsync = $cache->get($cachekey);
+
+        if ($lastsync && (time() - $lastsync) < 300) {
+            // Already synced within the last 5 minutes, skip.
+            return;
+        }
+
+        // Trigger a targeted sync for this user's org only.
+        try {
+            self::sync_user_org_roles($user, $ssoorg, $ssogroups);
+            $cache->set($cachekey, time());
+        } catch (\Exception $e) {
+            debugging('block_crucible: Failed to sync org roles for user ' . $userid . ': ' . $e->getMessage(), DEBUG_DEVELOPER);
+        }
+    }
+
+    /**
+     * Sync organization roles for a specific user.
+     * This is a lightweight version of the scheduled task that only processes one user's org.
+     *
+     * @param object $user
+     * @param string $ssoorg
+     * @param string $ssogroups
+     */
+    private static function sync_user_org_roles($user, string $ssoorg, string $ssogroups) {
+        global $CFG, $DB;
+
+        require_once($CFG->dirroot . '/cohort/lib.php');
+        require_once($CFG->libdir  . '/accesslib.php');
+
+        // Ensure the org category exists.
+        $categoryid = self::ensure_org_category($ssoorg);
+        if (!$categoryid) {
+            return;
+        }
+
+        // Parse user's groups (comma-separated).
+        $usergroups = array_filter(array_map('trim', explode(',', $ssogroups)));
+
+        // Map of group names to role shortnames.
+        $groupRoleMap = [
+            'cyber-managers'        => 'cyber-manager',
+            'lab-builders'          => 'lab-builder',
+            'curriculum-developers' => 'curriculum-developer',
+        ];
+
+        foreach ($groupRoleMap as $group => $roleshort) {
+            if (!in_array($group, $usergroups, true)) {
+                continue;
+            }
+
+            // User has this group, ensure they have the role.
+            $role = $DB->get_record('role', ['shortname' => $roleshort], 'id', IGNORE_MISSING);
+            if (!$role) {
+                continue;
+            }
+
+            $catctx = \context_coursecat::instance($categoryid);
+
+            // Check if user already has this role.
+            if (!$DB->record_exists('role_assignments', [
+                'roleid'    => $role->id,
+                'contextid' => $catctx->id,
+                'userid'    => $user->id,
+                'component' => 'block_crucible',
+            ])) {
+                // Assign the role.
+                role_assign($role->id, $user->id, $catctx->id, 'block_crucible', 0);
+            }
+        }
+
+        // Clear cache.
+        if (class_exists('\\cache_helper')) {
+            \cache_helper::purge_by_event('changesincapabilities');
+        }
+    }
+
+    /**
+     * Ensure org category exists (simplified version).
+     *
+     * @param string $org
+     * @return int Category ID or 0 on failure
+     */
+    private static function ensure_org_category(string $org): int {
+        global $DB;
+
+        $existing = $DB->get_record('course_categories', ['name' => $org, 'parent' => 0], 'id', IGNORE_MISSING);
+        if ($existing) {
+            return (int)$existing->id;
+        }
+
+        $idnumber = 'org-' . self::slugify($org);
+
+        if ($DB->record_exists('course_categories', ['idnumber' => $idnumber])) {
+            $cat = $DB->get_record('course_categories', ['idnumber' => $idnumber], 'id', IGNORE_MISSING);
+            return $cat ? (int)$cat->id : 0;
+        }
+
+        try {
+            $category = \core_course_category::create((object)[
+                'name'              => $org,
+                'idnumber'          => $idnumber,
+                'parent'            => 0,
+                'description'       => '',
+                'descriptionformat' => FORMAT_HTML,
+            ]);
+            return (int)$category->id;
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Convert string to slug.
+     *
+     * @param string $value
+     * @return string
+     */
+    private static function slugify(string $value): string {
+        return strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', trim($value)));
+    }
+}

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -47,7 +47,8 @@ class observer {
 
     /**
      * Triggered when a user logs in.
-     * Syncs the user's organization roles if they have ssoorg and ssogroups data.
+     * Syncs the user's organization roles if they have ssoorg and ssogroups data,
+     * and if a matching course category exists (must be created manually by admins).
      *
      * @param \core\event\user_loggedin $event
      */
@@ -101,6 +102,7 @@ class observer {
     /**
      * Sync organization roles for a specific user.
      * This is a lightweight version of the scheduled task that only processes one user's org.
+     * Only syncs if a course category matching the org name already exists (must be created manually).
      *
      * @param object $user
      * @param string $ssoorg
@@ -112,9 +114,10 @@ class observer {
         require_once($CFG->dirroot . '/cohort/lib.php');
         require_once($CFG->libdir  . '/accesslib.php');
 
-        // Ensure the org category exists.
-        $categoryid = self::ensure_org_category($ssoorg);
+        // Check if the org category exists (must be created manually by admins).
+        $categoryid = self::get_org_category($ssoorg);
         if (!$categoryid) {
+            // Category doesn't exist yet - will be synced by scheduled task once created.
             return;
         }
 
@@ -160,38 +163,31 @@ class observer {
     }
 
     /**
-     * Ensure org category exists (simplified version).
+     * Check if org category exists.
+     * Returns the category id if it exists, or 0 if it doesn't.
+     * Categories must be manually created by administrators.
      *
      * @param string $org
-     * @return int Category ID or 0 on failure
+     * @return int Category ID or 0 if not found
      */
-    private static function ensure_org_category(string $org): int {
+    private static function get_org_category(string $org): int {
         global $DB;
 
+        // Look for exact match by name (case-sensitive)
         $existing = $DB->get_record('course_categories', ['name' => $org, 'parent' => 0], 'id', IGNORE_MISSING);
         if ($existing) {
             return (int)$existing->id;
         }
 
+        // Also check by idnumber in case it was created with the expected idnumber pattern
         $idnumber = 'org-' . self::slugify($org);
-
-        if ($DB->record_exists('course_categories', ['idnumber' => $idnumber])) {
-            $cat = $DB->get_record('course_categories', ['idnumber' => $idnumber], 'id', IGNORE_MISSING);
-            return $cat ? (int)$cat->id : 0;
+        $cat = $DB->get_record('course_categories', ['idnumber' => $idnumber, 'parent' => 0], 'id', IGNORE_MISSING);
+        if ($cat) {
+            return (int)$cat->id;
         }
 
-        try {
-            $category = \core_course_category::create((object)[
-                'name'              => $org,
-                'idnumber'          => $idnumber,
-                'parent'            => 0,
-                'description'       => '',
-                'descriptionformat' => FORMAT_HTML,
-            ]);
-            return (int)$category->id;
-        } catch (\Exception $e) {
-            return 0;
-        }
+        // Category doesn't exist - admin needs to create it manually
+        return 0;
     }
 
     /**

--- a/classes/reports.php
+++ b/classes/reports.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace block_crucible;
 
 defined('MOODLE_INTERNAL') || die();
@@ -6,9 +7,11 @@ defined('MOODLE_INTERNAL') || die();
 use context_system;
 use core_user\fields;
 
-class reports {
+class reports
+{
 
-    public function get_cohort_roster_all(int $userid): \stdClass {
+    public function get_cohort_roster_all(int $userid): \stdClass
+    {
         global $DB;
 
         $info = (object)[
@@ -102,8 +105,7 @@ class reports {
         }
 
         // Fetch cohort-configured roles
-        $cohortrolesByCU = [];
-        {
+        $cohortrolesByCU = []; {
             // Cohort IDs
             $cohortids = array_map('intval', array_keys($byCohort));
             // User IDs
@@ -132,9 +134,40 @@ class reports {
             }
         }
 
+        // Fetch category-level roles assigned by block_crucible org role sync
+        $categoryRolesByUser = [];
+        {
+            $userids = array_map('intval', array_keys($allUserIds));
+
+            if ($userids) {
+                list($uInSql3, $uParams3) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED, 'uid');
+
+                $sql3 = "
+                    SELECT DISTINCT
+                        ra.userid,
+                        COALESCE(NULLIF(r.name, ''), r.shortname) AS roledisplay
+                    FROM {role_assignments} ra
+                    JOIN {role} r ON r.id = ra.roleid
+                    JOIN {context} ctx ON ra.contextid = ctx.id
+                    WHERE ra.component = 'block_crucible'
+                    AND ctx.contextlevel = 40
+                    AND ra.userid {$uInSql3}
+                ";
+                $rows3 = $DB->get_records_sql($sql3, $uParams3);
+
+                foreach ($rows3 as $row) {
+                    $categoryRolesByUser[(int)$row->userid][] = trim($row->roledisplay);
+                }
+            }
+        }
+
         foreach ($byCohort as &$c) {
             foreach ($c['users'] as $uid => $u) {
-                $cr = $cohortrolesByCU[$c['id']][$uid] ?? [];
+                // Merge cohort roles and category roles
+                $cr = array_merge(
+                    $cohortrolesByCU[$c['id']][$uid] ?? [],
+                    $categoryRolesByUser[$uid] ?? []
+                );
                 if ($cr) {
                     $cr = array_values(array_unique($cr));
                     sort($cr, SORT_NATURAL | SORT_FLAG_CASE);
@@ -163,10 +196,11 @@ class reports {
         return $info;
     }
 
-    private function get_user_cohort_ids(int $userid): array {
+    private function get_user_cohort_ids(int $userid): array
+    {
         global $CFG;
         require_once($CFG->dirroot . '/cohort/lib.php');
-        $cohorts = cohort_get_user_cohorts($userid);
+        $cohorts = \cohort_get_user_cohorts($userid);
         return array_map('intval', array_keys($cohorts));
     }
 }

--- a/classes/task/sync_org_roles.php
+++ b/classes/task/sync_org_roles.php
@@ -1,0 +1,462 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/*
+Crucible Applications Landing Page Block for Moodle
+
+Copyright 2024 Carnegie Mellon University.
+
+NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS.
+CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO,
+WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL.
+CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+Licensed under a GNU GENERAL PUBLIC LICENSE - Version 3, 29 June 2007-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+
+[DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution. Please see Copyright notice for non-US Government use and distribution.
+
+This Software includes and/or makes use of Third-Party Software each subject to its own license.
+
+DM24-1176
+*/
+
+namespace block_crucible\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Scheduled task: sync Keycloak org group memberships to Moodle category-scoped roles.
+ *
+ * Each run:
+ *   1. Reads all distinct profile_field_ssoorg values from user profiles.
+ *   2. Ensures a top-level course category exists for each org.
+ *   3. Ensures a dynamic cohort exists for each org × Keycloak group combination,
+ *      filtered on auth=oauth2 + ssoorg contains org + ssogroups contains group.
+ *   4. Syncs cohort members to the matching role assignment in the org's category context.
+ *
+ * Adding a new org requires no code changes — it is discovered automatically once
+ * a user with that ssoorg value logs in via Keycloak.
+ *
+ * Adding a new group/role mapping only requires extending GROUP_ROLE_MAP.
+ *
+ * @package    block_crucible
+ * @copyright  2024 Carnegie Mellon University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class sync_org_roles extends \core\task\scheduled_task {
+
+    /**
+     * Maps Keycloak group name => Moodle role shortname.
+     * The roles must already exist (created by the moodle-install.sh setup script).
+     */
+    const GROUP_ROLE_MAP = [
+        'cyber-managers'        => 'cyber-manager',
+        'lab-builders'          => 'lab-builder',
+        'curriculum-developers' => 'curriculum-developer',
+    ];
+
+    /**
+     * @return string
+     */
+    public function get_name(): string {
+        return get_string('task_sync_org_roles', 'block_crucible');
+    }
+
+    /**
+     * Execute the scheduled task.
+     */
+    public function execute(): void {
+        global $CFG, $DB;
+
+        // Check if org role sync is enabled.
+        if (!get_config('block_crucible', 'enableorgrolesync')) {
+            mtrace('sync_org_roles: org role sync is disabled in plugin settings - skipping.');
+            return;
+        }
+
+        // Check for required dependencies before proceeding.
+        if (!$DB->get_manager()->table_exists('tool_dynamic_cohorts')) {
+            mtrace('sync_org_roles: tool_dynamic_cohorts plugin not installed - skipping.');
+            return;
+        }
+
+        $ssoorgifield = $DB->get_record('user_info_field', ['shortname' => 'ssoorg'], 'id', IGNORE_MISSING);
+        if (!$ssoorgifield) {
+            mtrace('sync_org_roles: profile field "ssoorg" not found - skipping.');
+            return;
+        }
+
+        $ssogroupsfield = $DB->get_record('user_info_field', ['shortname' => 'ssogroups'], 'id', IGNORE_MISSING);
+        if (!$ssogroupsfield) {
+            mtrace('sync_org_roles: profile field "ssogroups" not found - skipping.');
+            return;
+        }
+
+        require_once($CFG->dirroot . '/cohort/lib.php');
+        require_once($CFG->libdir  . '/accesslib.php');
+
+        $orgs = $this->get_distinct_orgs();
+
+        if (empty($orgs)) {
+            mtrace('sync_org_roles: no ssoorg values found in user profiles — nothing to do.');
+            return;
+        }
+
+        foreach ($orgs as $org) {
+            mtrace("sync_org_roles: processing org '{$org}'");
+
+            $categoryid = $this->ensure_org_category($org);
+            if (!$categoryid) {
+                mtrace("  skipping '{$org}': could not resolve category.");
+                continue;
+            }
+
+            foreach (self::GROUP_ROLE_MAP as $group => $roleshort) {
+                $cohortname  = $org . ' ' . ucwords(str_replace('-', ' ', $group));
+                $cohortidnum = $this->slugify($org) . '-' . $group;
+
+                try {
+                    $cohortid = $this->ensure_org_group_cohort($cohortname, $cohortidnum, $org, $group);
+                    $this->sync_cohort_category_role($cohortname, $cohortid, $roleshort, $categoryid);
+                } catch (\Exception $e) {
+                    mtrace("  ERROR processing '{$cohortname}': " . $e->getMessage());
+                    continue;
+                }
+            }
+        }
+
+        mtrace('sync_org_roles: completed.');
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return all distinct non-empty ssoorg profile field values across all users.
+     *
+     * @return array
+     */
+    private function get_distinct_orgs(): array {
+        global $DB;
+
+        $field = $DB->get_record('user_info_field', ['shortname' => 'ssoorg'], 'id', IGNORE_MISSING);
+        if (!$field) {
+            mtrace('sync_org_roles: profile field "ssoorg" not found.');
+            return [];
+        }
+
+        $values = $DB->get_fieldset_sql(
+            'SELECT DISTINCT data FROM {user_info_data} WHERE fieldid = ? AND ' .
+            $DB->sql_isnotempty('user_info_data', 'data', false, true),
+            [$field->id]
+        );
+
+        return array_filter(array_map('trim', $values));
+    }
+
+    /**
+     * Ensure a top-level course category named after the org exists.
+     * Returns the category id, or 0 on failure.
+     *
+     * @param string $org
+     * @return int
+     */
+    private function ensure_org_category(string $org): int {
+        global $DB;
+
+        $existing = $DB->get_record('course_categories', ['name' => $org, 'parent' => 0], 'id', IGNORE_MISSING);
+        if ($existing) {
+            mtrace("  category '{$org}' already exists (id: {$existing->id}).");
+            return (int)$existing->id;
+        }
+
+        $idnumber = 'org-' . $this->slugify($org);
+
+        // Guard against duplicate idnumber from a previous partial run.
+        if ($DB->record_exists('course_categories', ['idnumber' => $idnumber])) {
+            // idnumber exists but name doesn't match — fetch by idnumber.
+            $cat = $DB->get_record('course_categories', ['idnumber' => $idnumber], 'id', IGNORE_MISSING);
+            return $cat ? (int)$cat->id : 0;
+        }
+
+        try {
+            $category = \core_course_category::create((object)[
+                'name'              => $org,
+                'idnumber'          => $idnumber,
+                'parent'            => 0,
+                'description'       => '',
+                'descriptionformat' => FORMAT_HTML,
+            ]);
+            mtrace("  created category '{$org}' (idnumber: {$idnumber}, id: {$category->id}).");
+            return (int)$category->id;
+        } catch (\Exception $e) {
+            mtrace("  ERROR creating category '{$org}': " . $e->getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * Ensure a dynamic cohort exists for the given org + Keycloak group combination,
+     * with conditions: auth=oauth2 AND ssoorg contains $org AND ssogroups contains $group.
+     * Returns the cohort id.
+     *
+     * @param string $cohortname
+     * @param string $cohortidnumber
+     * @param string $orgvalue
+     * @param string $groupvalue
+     * @return int
+     * @throws \dml_exception
+     */
+    private function ensure_org_group_cohort(
+        string $cohortname,
+        string $cohortidnumber,
+        string $orgvalue,
+        string $groupvalue
+    ): int {
+        global $DB;
+
+        $sysctx  = \context_system::instance();
+        $adminid = (int)get_admin()->id;
+        $now     = time();
+
+        // Upsert cohort.
+        $cohort = $DB->get_record('cohort', ['idnumber' => $cohortidnumber, 'contextid' => $sysctx->id]);
+        if (!$cohort) {
+            $cohort = (object)[
+                'contextid'         => $sysctx->id,
+                'name'              => $cohortname,
+                'idnumber'          => $cohortidnumber,
+                'description'       => "Auto-managed: org={$orgvalue}, group={$groupvalue}",
+                'descriptionformat' => FORMAT_HTML,
+                'visible'           => 1,
+                'component'         => 'tool_dynamic_cohorts',
+                'timecreated'       => $now,
+                'timemodified'      => $now,
+            ];
+            $cohort->id = cohort_add_cohort($cohort);
+            mtrace("  created cohort '{$cohortname}' (id: {$cohort->id}).");
+        } else {
+            mtrace("  cohort '{$cohortname}' exists (id: {$cohort->id}).");
+        }
+
+        // Upsert dynamic rule.
+        $CLASS_AUTH    = 'tool_dynamic_cohorts\\local\\tool_dynamic_cohorts\\condition\\auth_method';
+        $CLASS_PROFILE = 'tool_dynamic_cohorts\\local\\tool_dynamic_cohorts\\condition\\user_custom_profile';
+
+        $rule = $DB->get_record('tool_dynamic_cohorts', ['name' => $cohortname]);
+        if ($rule) {
+            $rule->cohortid     = $cohort->id;
+            $rule->enabled      = 1;
+            $rule->realtime     = 1;
+            $rule->operator     = 0; // AND
+            $rule->usermodified = $adminid;
+            $rule->timemodified = $now;
+            $DB->update_record('tool_dynamic_cohorts', $rule);
+            $ruleid = (int)$rule->id;
+        } else {
+            $ruleid = (int)$DB->insert_record('tool_dynamic_cohorts', (object)[
+                'name'           => $cohortname,
+                'description'    => '',
+                'cohortid'       => $cohort->id,
+                'enabled'        => 1,
+                'bulkprocessing' => 0,
+                'broken'         => 0,
+                'operator'       => 0, // AND
+                'realtime'       => 1,
+                'usermodified'   => $adminid,
+                'timecreated'    => $now,
+                'timemodified'   => $now,
+            ], true);
+            mtrace("  created dynamic rule '{$cohortname}' (id: {$ruleid}).");
+        }
+
+        // Condition 0: auth = oauth2.
+        $this->upsert_condition($ruleid, $CLASS_AUTH, [
+            'authmethod'    => 'auth',
+            'auth_operator' => '3',
+            'auth_value'    => 'oauth2',
+        ], 0, $adminid, $now);
+
+        // Conditions 1 & 2: ssoorg and ssogroups profile fields.
+        // Two conditions share the same classname; distinguish by 'profilefield' in configdata.
+        $orgkey = 'profile_field_ssoorg';
+        $grpkey = 'profile_field_ssogroups';
+
+        $orgcfg = ['profilefield' => $orgkey, "{$orgkey}_operator" => '1', "{$orgkey}_value" => $orgvalue, 'include_missing_data' => 0];
+        $grpcfg = ['profilefield' => $grpkey, "{$grpkey}_operator" => '1', "{$grpkey}_value" => $groupvalue, 'include_missing_data' => 0];
+
+        $orgcond = null;
+        $grpcond = null;
+        foreach ($DB->get_records('tool_dynamic_cohorts_c', ['ruleid' => $ruleid, 'classname' => $CLASS_PROFILE]) as $rec) {
+            $cfg = json_decode($rec->configdata, true);
+            if (isset($cfg['profilefield'])) {
+                if ($cfg['profilefield'] === $orgkey) { $orgcond = $rec; }
+                if ($cfg['profilefield'] === $grpkey) { $grpcond = $rec; }
+            }
+        }
+
+        $this->upsert_profile_condition($orgcond, $ruleid, $CLASS_PROFILE, $orgcfg, 1, $adminid, $now);
+        $this->upsert_profile_condition($grpcond, $ruleid, $CLASS_PROFILE, $grpcfg, 2, $adminid, $now);
+
+        if (class_exists('\\cache_helper')) {
+            \cache_helper::purge_all();
+        }
+
+        return (int)$cohort->id;
+    }
+
+    /**
+     * Sync all members of a cohort to a role assignment in a course category context.
+     * Uses component='block_crucible' to distinguish managed assignments from manual ones.
+     * Adds missing assignments and removes stale ones.
+     *
+     * @param string $cohortname
+     * @param int $cohortid
+     * @param string $roleshortname
+     * @param int $categoryid
+     */
+    private function sync_cohort_category_role(
+        string $cohortname,
+        int $cohortid,
+        string $roleshortname,
+        int $categoryid
+    ): void {
+        global $DB;
+
+        $role = $DB->get_record('role', ['shortname' => $roleshortname], 'id', IGNORE_MISSING);
+        if (!$role) {
+            mtrace("  WARNING: role '{$roleshortname}' not found — skipping sync for '{$cohortname}'.");
+            return;
+        }
+
+        $catctx = \context_coursecat::instance($categoryid);
+
+        $memberids  = array_map('intval', array_keys(
+            $DB->get_records('cohort_members', ['cohortid' => $cohortid], '', 'userid')
+        ));
+        $existingids = array_map('intval', array_keys(
+            $DB->get_records('role_assignments', [
+                'roleid'    => $role->id,
+                'contextid' => $catctx->id,
+                'component' => 'block_crucible',
+            ], '', 'userid')
+        ));
+
+        $added = 0;
+        foreach ($memberids as $userid) {
+            if (!in_array($userid, $existingids, true)) {
+                role_assign($role->id, $userid, $catctx->id, 'block_crucible', 0);
+                $added++;
+            }
+        }
+
+        $removed = 0;
+        foreach ($existingids as $userid) {
+            if (!in_array($userid, $memberids, true)) {
+                role_unassign($role->id, $userid, $catctx->id, 'block_crucible', 0);
+                $removed++;
+            }
+        }
+
+        if (class_exists('\\cache_helper')) {
+            \cache_helper::purge_by_event('changesincapabilities');
+        }
+
+        mtrace("  '{$cohortname}' → '{$roleshortname}': +{$added} added, -{$removed} removed.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Condition helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Upsert a condition record.
+     *
+     * @param int $ruleid
+     * @param string $classname
+     * @param array $config
+     * @param int $sortorder
+     * @param int $adminid
+     * @param int $now
+     */
+    private function upsert_condition(int $ruleid, string $classname, array $config, int $sortorder, int $adminid, int $now): void {
+        global $DB;
+
+        $json     = json_encode($config, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $existing = $DB->get_record('tool_dynamic_cohorts_c', ['ruleid' => $ruleid, 'classname' => $classname]);
+        if ($existing) {
+            $existing->configdata   = $json;
+            $existing->sortorder    = $sortorder;
+            $existing->usermodified = $adminid;
+            $existing->timemodified = $now;
+            $DB->update_record('tool_dynamic_cohorts_c', $existing);
+        } else {
+            $DB->insert_record('tool_dynamic_cohorts_c', (object)[
+                'ruleid'       => $ruleid,
+                'classname'    => $classname,
+                'configdata'   => $json,
+                'sortorder'    => $sortorder,
+                'usermodified' => $adminid,
+                'timecreated'  => $now,
+                'timemodified' => $now,
+            ]);
+        }
+    }
+
+    /**
+     * Upsert a profile field condition record.
+     *
+     * @param object|null $existing
+     * @param int $ruleid
+     * @param string $classname
+     * @param array $config
+     * @param int $sortorder
+     * @param int $adminid
+     * @param int $now
+     */
+    private function upsert_profile_condition(?object $existing, int $ruleid, string $classname, array $config, int $sortorder, int $adminid, int $now): void {
+        global $DB;
+
+        $json = json_encode($config, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($existing) {
+            $existing->configdata   = $json;
+            $existing->sortorder    = $sortorder;
+            $existing->usermodified = $adminid;
+            $existing->timemodified = $now;
+            $DB->update_record('tool_dynamic_cohorts_c', $existing);
+        } else {
+            $DB->insert_record('tool_dynamic_cohorts_c', (object)[
+                'ruleid'       => $ruleid,
+                'classname'    => $classname,
+                'configdata'   => $json,
+                'sortorder'    => $sortorder,
+                'usermodified' => $adminid,
+                'timecreated'  => $now,
+                'timemodified' => $now,
+            ]);
+        }
+    }
+
+    /**
+     * Convert a string to a slug.
+     *
+     * @param string $value
+     * @return string
+     */
+    private function slugify(string $value): string {
+        return strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', trim($value)));
+    }
+}

--- a/classes/task/sync_org_roles.php
+++ b/classes/task/sync_org_roles.php
@@ -41,13 +41,15 @@ defined('MOODLE_INTERNAL') || die();
  *
  * Each run:
  *   1. Reads all distinct profile_field_ssoorg values from user profiles.
- *   2. Ensures a top-level course category exists for each org.
+ *   2. Looks for matching top-level course categories (must be created manually by admins).
  *   3. Ensures a dynamic cohort exists for each org × Keycloak group combination,
  *      filtered on auth=oauth2 + ssoorg contains org + ssogroups contains group.
  *   4. Syncs cohort members to the matching role assignment in the org's category context.
  *
- * Adding a new org requires no code changes — it is discovered automatically once
- * a user with that ssoorg value logs in via Keycloak.
+ * Adding a new org requires:
+ *   1. Admin manually creates a top-level course category with the org's exact name.
+ *   2. This task will discover the category and assign roles on its next run.
+ *   This prevents automatic category creation from typos or unauthorized orgs.
  *
  * Adding a new group/role mapping only requires extending GROUP_ROLE_MAP.
  *
@@ -117,9 +119,9 @@ class sync_org_roles extends \core\task\scheduled_task {
         foreach ($orgs as $org) {
             mtrace("sync_org_roles: processing org '{$org}'");
 
-            $categoryid = $this->ensure_org_category($org);
+            $categoryid = $this->get_org_category($org);
             if (!$categoryid) {
-                mtrace("  skipping '{$org}': could not resolve category.");
+                // Category doesn't exist - skip this org entirely
                 continue;
             }
 
@@ -168,44 +170,35 @@ class sync_org_roles extends \core\task\scheduled_task {
     }
 
     /**
-     * Ensure a top-level course category named after the org exists.
-     * Returns the category id, or 0 on failure.
+     * Check if a top-level course category named after the org exists.
+     * Returns the category id if it exists, or 0 if it doesn't.
+     *
+     * Note: Categories must be manually created by administrators.
+     * This prevents automatic creation of categories due to typos or unauthorized orgs.
      *
      * @param string $org
      * @return int
      */
-    private function ensure_org_category(string $org): int {
+    private function get_org_category(string $org): int {
         global $DB;
 
+        // Look for exact match by name (case-sensitive)
         $existing = $DB->get_record('course_categories', ['name' => $org, 'parent' => 0], 'id', IGNORE_MISSING);
         if ($existing) {
-            mtrace("  category '{$org}' already exists (id: {$existing->id}).");
+            mtrace("  category '{$org}' found (id: {$existing->id}).");
             return (int)$existing->id;
         }
 
+        // Also check by idnumber in case it was created with the expected idnumber pattern
         $idnumber = 'org-' . $this->slugify($org);
-
-        // Guard against duplicate idnumber from a previous partial run.
-        if ($DB->record_exists('course_categories', ['idnumber' => $idnumber])) {
-            // idnumber exists but name doesn't match — fetch by idnumber.
-            $cat = $DB->get_record('course_categories', ['idnumber' => $idnumber], 'id', IGNORE_MISSING);
-            return $cat ? (int)$cat->id : 0;
+        $cat = $DB->get_record('course_categories', ['idnumber' => $idnumber, 'parent' => 0], 'id', IGNORE_MISSING);
+        if ($cat) {
+            mtrace("  category found by idnumber '{$idnumber}' (id: {$cat->id}).");
+            return (int)$cat->id;
         }
 
-        try {
-            $category = \core_course_category::create((object)[
-                'name'              => $org,
-                'idnumber'          => $idnumber,
-                'parent'            => 0,
-                'description'       => '',
-                'descriptionformat' => FORMAT_HTML,
-            ]);
-            mtrace("  created category '{$org}' (idnumber: {$idnumber}, id: {$category->id}).");
-            return (int)$category->id;
-        } catch (\Exception $e) {
-            mtrace("  ERROR creating category '{$org}': " . $e->getMessage());
-            return 0;
-        }
+        mtrace("  category '{$org}' does not exist - skipping (create it manually to enable role sync).");
+        return 0;
     }
 
     /**
@@ -314,6 +307,9 @@ class sync_org_roles extends \core\task\scheduled_task {
         if (class_exists('\\cache_helper')) {
             \cache_helper::purge_all();
         }
+
+        // Queue adhoc task to process this dynamic cohort rule immediately
+        $this->queue_cohort_processing($ruleid);
 
         return (int)$cohort->id;
     }
@@ -458,5 +454,29 @@ class sync_org_roles extends \core\task\scheduled_task {
      */
     private function slugify(string $value): string {
         return strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', trim($value)));
+    }
+
+    /**
+     * Queue an adhoc task to process the dynamic cohort rule immediately.
+     *
+     * @param int $ruleid The dynamic cohort rule ID
+     */
+    private function queue_cohort_processing(int $ruleid): void {
+        // Check if the adhoc task class exists
+        if (!class_exists('tool_dynamic_cohorts\\task\\process_rule')) {
+            mtrace("  WARNING: tool_dynamic_cohorts plugin not found - cohort membership may be delayed.");
+            return;
+        }
+
+        try {
+            // Queue adhoc task to process this specific rule (same as scheduled task does)
+            $adhoctask = new \tool_dynamic_cohorts\task\process_rule();
+            $adhoctask->set_custom_data($ruleid);
+            $adhoctask->set_component('tool_dynamic_cohorts');
+            \core\task\manager::queue_adhoc_task($adhoctask, true);
+            mtrace("  queued cohort processing task for rule (id: {$ruleid}).");
+        } catch (\Exception $e) {
+            mtrace("  WARNING: failed to queue cohort processing: " . $e->getMessage());
+        }
     }
 }

--- a/db/caches.php
+++ b/db/caches.php
@@ -33,16 +33,22 @@ DM24-1176
 */
 
 /**
- * Global Search version details.
+ * Cache definitions for block_crucible.
  *
  * @package    block_crucible
  * @copyright  2024 Carnegie Mellon University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026031200;
-$plugin->requires  = 2025041400;
-$plugin->component = 'block_crucible';
-$plugin->maturity = MATURITY_ALPHA;
+$definitions = [
+    'org_role_sync' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+        'ttl' => 300, // 5 minutes
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 100,
+    ],
+];

--- a/db/events.php
+++ b/db/events.php
@@ -33,16 +33,19 @@ DM24-1176
 */
 
 /**
- * Global Search version details.
+ * Event observers for block_crucible.
  *
  * @package    block_crucible
  * @copyright  2024 Carnegie Mellon University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026031200;
-$plugin->requires  = 2025041400;
-$plugin->component = 'block_crucible';
-$plugin->maturity = MATURITY_ALPHA;
+$observers = [
+    [
+        'eventname' => '\core\event\user_loggedin',
+        'callback'  => '\block_crucible\observer::user_loggedin',
+        'internal'  => true,
+    ],
+];

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -11,4 +11,13 @@ $tasks = [
         'dayofweek' => '*',
         'month'     => '*',
     ],
+    [
+        'classname' => '\block_crucible\task\sync_org_roles',
+        'blocking'  => 0,
+        'minute'    => '0',
+        'hour'      => '*',
+        'day'       => '*',
+        'month'     => '*',
+        'dayofweek' => '*',
+    ],
 ];

--- a/lang/en/block_crucible.php
+++ b/lang/en/block_crucible.php
@@ -297,6 +297,11 @@ $string['unmapped_summary']  = 'Unmapped {$a} Competencies';
 $string['unmapped_for_framework_title'] = 'Unmapped Competencies — {$a}';
 $string['unmapped_list_empty'] = 'No unmapped competencies in this framework.';
 $string['task_sync_keycloak_users'] = 'Sync Keycloak Users to Moodle';
+$string['task_sync_org_roles'] = 'Sync Org Group Roles';
+$string['orgrolsyncsectionheading'] = 'Organization Role Sync';
+$string['orgrolsyncsectiondesc'] = 'Configure automatic syncing of Keycloak group memberships to Moodle category-scoped roles based on user organization.';
+$string['enableorgrolesync'] = 'Enable Organization Role Sync';
+$string['configenableorgrolesync'] = 'When enabled, automatically assigns organization-scoped roles to users based on their Keycloak group membership. This runs as a scheduled task hourly and also on user login.';
 $string['learning_plan'] = 'Learning Plan';
 $string['framework'] = 'Framework';
 

--- a/settings.php
+++ b/settings.php
@@ -79,7 +79,17 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('block_crucible/customwelcomemessage',
         get_string('customwelcomemessage', 'block_crucible'), get_string('configcustomwelcomemessage', 'block_crucible'),
          "", PARAM_RAW, 60));
-    
+
+    // Organization Role Sync Settings
+    $settings->add(new admin_setting_heading(
+        'block_crucible/orgrolsyncsectionheading',
+        get_string('orgrolsyncsectionheading', 'block_crucible'),
+        get_string('orgrolsyncsectiondesc', 'block_crucible')
+    ));
+
+    $settings->add(new admin_setting_configcheckbox('block_crucible/enableorgrolesync',
+        get_string('enableorgrolesync', 'block_crucible'),
+        get_string('configenableorgrolesync', 'block_crucible'), 0, 1, 0));
 
     // Alloy
     $settings->add(new admin_setting_heading(

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026031200;
+$plugin->version = 2026031204;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
### Summary                                                                                                           

  Implements automated synchronization of Keycloak organization group memberships to Moodle category-scoped roles.
  This allows organization administrators to manage content within their own course categories based on their
  Keycloak group memberships. Categories must be manually created by administrators to prevent unauthorized category
   creation.

  ### Features Added

  **1. Scheduled Task (sync_org_roles.php)**

  Periodically syncs organization roles for all users:
  - Discovers organizations from user profile field ssoorg
  - Checks for existing course categories (must be manually created by admins)
  - Creates/manages dynamic cohorts for each org × group combination
    - Filters: auth=oauth2 AND ssoorg contains org AND ssogroups contains group
  - Syncs cohort members to category roles
    - Adds missing role assignments
    - Removes stale role assignments
    - Uses component='block_crucible' to track managed assignments
  - Queues adhoc tasks to process dynamic cohorts immediately

  **Group → Role Mapping:**
  'cyber-managers'        => 'cyber-manager'
  'lab-builders'          => 'lab-builder'
  'curriculum-developers' => 'curriculum-developer'

  **2. Login Observer (observer.php)**

  Provides real-time role assignment when users log in:
  - Triggers on user login event (OAuth2 users only)
  - Throttles syncs - max once per 5 minutes using cache
  - Checks for existing category matching user's ssoorg
  - Assigns roles immediately based on user's ssogroups
  - Skips users without categories until admin creates them

  **3. Plugin Settings (settings.php)**

  - Enable/disable toggle - enableorgrolesync setting
  - Allows administrators to control whether org role sync is active

  **4. Language Strings (lang/en/block_crucible.php)**

  - Task name: "Sync Org Group Roles"
  - Setting name: "Enable organization role sync"
  - Setting description with detailed explanation

  **5. Cache Definition (db/caches.php)**

  - Application-level cache for throttling login observer
  - 5-minute TTL to prevent repeated syncs on multiple logins
  - Static acceleration for performance

  **6. Event Observers (db/events.php)**

  - Observes \core\event\user_loggedin
  - Triggers block_crucible\observer::user_loggedin()

###   Architecture Decisions

  **Manual Category Creation**

  Categories are NOT automatically created. Administrators must manually create course categories for each
  organization:

  **Benefits:**
  - ✅ Prevents typo-induced category sprawl
  - ✅ Administrative control over which orgs get categories
  - ✅ Prevents unauthorized organizations from creating categories

  **Category Requirements:**
  - Top-level (parent = 0)
  - Name must match the org value from user's ssoorg field exactly
  - Optional idnumber: org-{slugified-name} (e.g., org-carnegie-mellon-university)

  **Component-Scoped Role Assignments**

  All role assignments use component='block_crucible':
  - Distinguishes managed assignments from manual ones
  - Allows safe cleanup of stale assignments
  - Won't interfere with manually assigned roles

  **Dynamic Cohorts Integration**

  Uses tool_dynamic_cohorts plugin for real-time user filtering:
  - Cohorts automatically update as users log in
  - Conditions evaluated in real-time (if realtime=1)
  - Adhoc tasks process membership changes

###   Configuration

  **Required Profile Fields**

  Must exist before task runs:
  - ssoorg - User's organization name
  - ssogroups - Comma-separated list of Keycloak groups

  **Required Roles**

  Must be created (usually by moodle-install.sh):
  - cyber-manager
  - lab-builder
  - curriculum-developer

  **Required Plugin**

  - tool_dynamic_cohorts - for dynamic cohort functionality

###   Usage

  **Initial Setup**

  1. Create custom profile fields: ssoorg, ssogroups
  2. Create the three custom roles with appropriate capabilities
  3. Enable org role sync in block settings
  4. Manually create course categories for each organization

###   Running the Task

  **Run manually**
  php admin/cli/scheduled_task.php --execute='\block_crucible\task\sync_org_roles'

  **Enable in scheduled tasks (runs periodically)**
  Site administration → Server → Scheduled tasks

###   Dependencies

  - Moodle 4.1+
  - tool_dynamic_cohorts plugin
  - Keycloak OAuth2 authentication configured
  - Custom profile fields: ssoorg, ssogroups