### PR TITLE
Remove 'docs' from reserved app names validation.

### DIFF
--- a/classes/form/app_form.php
+++ b/classes/form/app_form.php
@@ -176,7 +176,7 @@ class app_form extends \moodleform {
             $reservedkeys = [
                 'player', 'alloy', 'blueprint', 'caster', 'cite',
                 'gallery', 'steamfitter', 'topomojo', 'gameboard',
-                'keycloak', 'docs',
+                'keycloak',
             ];
             if (in_array($key, $reservedkeys)) {
                 $errors['name'] = get_string('appnamereserved', 'block_crucible');

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026051202;
+$plugin->version = 2026051500;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
The 'docs' application was removed from the hardcoded apps list but remained in the reserved names validation, incorrectly preventing users from creating custom apps named 'docs'.