### PR TITLE
fix: support dark theme in Crucible block

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -300,3 +300,221 @@
 .crucible-drop-line::after {
   right: -4px;
 }
+
+/*
+ * Boost Dark provides a palette but not all Bootstrap semantic variables.
+ * Keep these values scoped to Crucible block components so they do not alter
+ * the rest of Moodle's page.
+ */
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) {
+  --crucible-surface: var(--bs-gray-1000, #1e1e25);
+  --crucible-surface-muted: var(--bs-gray-900, #2e3134);
+  --crucible-surface-subtle: var(--bs-gray-800, #393e4f);
+  --crucible-border: var(--bs-gray-700, #495057);
+  --crucible-text: var(--bs-text-color, #cbd0d4);
+  --crucible-text-strong: var(--bs-gray-200, #e9ecef);
+  --crucible-text-muted: var(--bs-gray-400, #ced4da);
+  --crucible-link: var(--bs-link-color, #8fc4ff);
+  --crucible-link-hover: var(--bs-link-hover-color, #b5daff);
+}
+
+[data-bs-theme="dark"] .crucible-card {
+  border-color: var(--crucible-border) !important;
+  background: var(--crucible-surface) !important;
+  color: var(--crucible-text);
+  box-shadow: 0 6px 16px rgb(0 0 0 / .25);
+}
+
+[data-bs-theme="dark"] .crucible-template-view .lp-search {
+  border-color: var(--crucible-border) !important;
+  background: var(--crucible-surface) !important;
+  color: var(--crucible-text-strong) !important;
+}
+
+[data-bs-theme="dark"] .crucible-template-view .lp-search::placeholder {
+  color: var(--crucible-text-muted);
+  opacity: 1;
+}
+
+[data-bs-theme="dark"] .crucible-template-view .lp-clear {
+  color: var(--crucible-text-muted);
+}
+
+[data-bs-theme="dark"] .crucible-card__header {
+  border-color: var(--crucible-border);
+  background: linear-gradient(
+    135deg,
+    var(--crucible-surface-subtle),
+    var(--crucible-surface-muted)
+  );
+}
+
+[data-bs-theme="dark"] .crucible-card__title,
+[data-bs-theme="dark"] .app-card__title,
+[data-bs-theme="dark"] .lp-cell--num {
+  color: var(--crucible-text-strong);
+}
+
+[data-bs-theme="dark"] :is(
+  .crucible-card__subtitle,
+  .comp-meta,
+  .notice--empty,
+  .role-line--ok,
+  .app-card__desc
+) {
+  color: var(--crucible-text-muted);
+}
+
+[data-bs-theme="dark"] :is(
+  .crucible-card__body,
+  .comp-table__header,
+  .lp-table thead th,
+  .crucible-lp .crucible-lp-row:hover,
+  .crucible-lp .lp-row:hover,
+  .crucible-template a:hover,
+  .crucible-comp a:hover .comp-table__row
+) {
+  background: var(--crucible-surface-muted);
+}
+
+[data-bs-theme="dark"] :is(
+  .comp-table,
+  .lp-table-wrap,
+  .notice--empty,
+  .app-card
+) {
+  border-color: var(--crucible-border);
+  background: var(--crucible-surface);
+  color: var(--crucible-text);
+}
+
+[data-bs-theme="dark"] :is(
+  .comp-table__header,
+  .comp-table__row,
+  .framework-band[role="rowgroup"] > .framework-band__inner,
+  .divider,
+  .lp-row
+) {
+  border-color: var(--crucible-border);
+  color: var(--crucible-text);
+}
+
+[data-bs-theme="dark"] .framework-band[role="rowgroup"] > .framework-band__inner {
+  background: var(--crucible-surface-subtle);
+}
+
+[data-bs-theme="dark"] :is(.framework-chip, .lp-chip) {
+  border-color: var(--crucible-border);
+  background: var(--crucible-surface-subtle);
+  color: var(--crucible-text-strong);
+}
+
+[data-bs-theme="dark"] :is(.comp-name, .lp-name a) {
+  color: var(--crucible-link);
+}
+
+[data-bs-theme="dark"] :is(.comp-name, .lp-name a):hover {
+  color: var(--crucible-link-hover);
+}
+
+[data-bs-theme="dark"] .unmapped-link {
+  border-color: #6f5207;
+  background: #241b06;
+  color: #f3d88c;
+}
+
+[data-bs-theme="dark"] .unmapped-link:focus,
+[data-bs-theme="dark"] .unmapped-link:hover {
+  background: #352809;
+}
+
+[data-bs-theme="dark"] .role-line--empty {
+  color: #ffb4ab;
+}
+
+[data-bs-theme="dark"] .app-card.drag-over {
+  background: var(--crucible-surface-subtle);
+}
+
+/*
+ * Several legacy views carry their light palette inline. These overrides are
+ * deliberately limited to Crucible block cards and their template toolbar.
+ */
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#fff"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#fff"] {
+  background: var(--crucible-surface) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#f8fafc"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#f8fafc"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#f1f5f9"] {
+  background: var(--crucible-surface-muted) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#eef2ff"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#e0e7ff"] {
+  background: var(--crucible-surface-subtle) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#dcfce7"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#dcfce7"] {
+  border-color: #20491e !important;
+  background: #0b180a !important;
+  color: #8abf84 !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#fffbeb"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#fffbeb"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#fff3d6"] {
+  border-color: #6f5207 !important;
+  background: #241b06 !important;
+  color: #f3d88c !important;
+}
+
+[data-bs-theme="dark"] .crucible-card > div[style*="linear-gradient"][style*="#e0f2fe"] {
+  border-color: var(--crucible-border) !important;
+  background: linear-gradient(
+    135deg,
+    var(--crucible-surface-subtle),
+    var(--crucible-surface-muted)
+  ) !important;
+}
+
+[data-bs-theme="dark"] .crucible-card > div[style*="linear-gradient"][style*="#fef3c7"] {
+  border-color: #6f5207 !important;
+  background: linear-gradient(135deg, #352809, var(--crucible-surface-muted)) !important;
+}
+
+[data-bs-theme="dark"] .crucible-card [style*="linear-gradient"][style*="#60a5fa"],
+[data-bs-theme="dark"] .crucible-card [style*="background:#2563eb"] {
+  background: var(--bs-primary, #2f6db2) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="#e5e7eb"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#e5e7eb"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#cbd5e1"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#dbeafe"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#f1f5f9"] {
+  border-color: var(--crucible-border) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="color:#0f172a"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#0f172a"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#1e3a8a"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#334155"] {
+  color: var(--crucible-text-strong) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#475569"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#64748b"],
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#6b7280"] {
+  color: var(--crucible-text-muted) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#1d4ed8"] {
+  color: var(--crucible-link) !important;
+}
+
+[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#92400e"] {
+  color: #f3d88c !important;
+}

--- a/styles.css
+++ b/styles.css
@@ -307,11 +307,11 @@
  * the rest of Moodle's page.
  */
 [data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) {
-  --crucible-surface: var(--bs-gray-1000, #1e1e25);
-  --crucible-surface-muted: var(--bs-gray-900, #2e3134);
-  --crucible-surface-subtle: var(--bs-gray-800, #393e4f);
+  --crucible-surface: var(--bs-gray-900, #2e3134);
+  --crucible-surface-muted: var(--bs-secondary-bg, #343a40);
+  --crucible-surface-subtle: var(--bs-tertiary-bg, #393e4f);
   --crucible-border: var(--bs-gray-700, #495057);
-  --crucible-text: var(--bs-text-color, #cbd0d4);
+  --crucible-text: var(--bs-body-color, #cbd0d4);
   --crucible-text-strong: var(--bs-gray-200, #e9ecef);
   --crucible-text-muted: var(--bs-gray-400, #ced4da);
   --crucible-link: var(--bs-link-color, #8fc4ff);
@@ -437,41 +437,23 @@
 }
 
 /*
- * Several legacy views carry their light palette inline. These overrides are
- * deliberately limited to Crucible block cards and their template toolbar.
+ * The learning-plan template changes visibility through JavaScript. Use its
+ * semantic classes rather than matching serialized inline style attributes;
+ * setting element.style.display can otherwise make those selectors stop
+ * matching and leave a light surface behind.
  */
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#fff"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#fff"] {
+[data-bs-theme="dark"] .lp-toolbar,
+[data-bs-theme="dark"] .lp-template__body,
+[data-bs-theme="dark"] .cru-group__content,
+[data-bs-theme="dark"] .cru-course,
+[data-bs-theme="dark"] .crucible-message-card__panel {
   background: var(--crucible-surface) !important;
 }
 
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#f8fafc"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#f8fafc"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#f1f5f9"] {
-  background: var(--crucible-surface-muted) !important;
-}
-
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#eef2ff"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#e0e7ff"] {
-  background: var(--crucible-surface-subtle) !important;
-}
-
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#dcfce7"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#dcfce7"] {
-  border-color: #20491e !important;
-  background: #0b180a !important;
-  color: #8abf84 !important;
-}
-
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="background:#fffbeb"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#fffbeb"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="background:#fff3d6"] {
-  border-color: #6f5207 !important;
-  background: #241b06 !important;
-  color: #f3d88c !important;
-}
-
-[data-bs-theme="dark"] .crucible-card > div[style*="linear-gradient"][style*="#e0f2fe"] {
+[data-bs-theme="dark"] :is(
+  .lp-template__header,
+  .crucible-message-card__header
+) {
   border-color: var(--crucible-border) !important;
   background: linear-gradient(
     135deg,
@@ -480,47 +462,94 @@
   ) !important;
 }
 
-[data-bs-theme="dark"] .crucible-card > div[style*="linear-gradient"][style*="#fef3c7"] {
-  border-color: #6f5207 !important;
-  background: linear-gradient(135deg, #352809, var(--crucible-surface-muted)) !important;
+[data-bs-theme="dark"] :is(
+  .lp-empty,
+  .cru-group > summary,
+  .cru-comp,
+  .cru-activities,
+  .lp-no-competencies,
+  .crucible-message-card__body
+) {
+  background: var(--crucible-surface-muted) !important;
 }
 
-[data-bs-theme="dark"] .crucible-card [style*="linear-gradient"][style*="#60a5fa"],
-[data-bs-theme="dark"] .crucible-card [style*="background:#2563eb"] {
-  background: var(--bs-primary, #2f6db2) !important;
-}
-
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="#e5e7eb"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#e5e7eb"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#cbd5e1"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#dbeafe"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="#f1f5f9"] {
+[data-bs-theme="dark"] :is(
+  .cru-group-count,
+  .cru-comp-id,
+  .crucible-message-card__logo
+) {
+  background: var(--crucible-surface-subtle) !important;
   border-color: var(--crucible-border) !important;
-}
-
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view)[style*="color:#0f172a"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#0f172a"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#1e3a8a"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#334155"] {
   color: var(--crucible-text-strong) !important;
 }
 
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#475569"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#64748b"],
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#6b7280"] {
+[data-bs-theme="dark"] :is(
+  .lp-empty,
+  .cru-group,
+  .cru-comp,
+  .cru-course,
+  .cru-activities,
+  .lp-no-competencies,
+  .crucible-message-card__panel,
+  .crucible-message-card__logo
+) {
+  border-color: var(--crucible-border) !important;
+}
+
+[data-bs-theme="dark"] :is(
+  .lp-template__title,
+  .lp-template__description,
+  .lp-template__section-title,
+  .cru-group__name,
+  .cru-comp-title,
+  .cru-comp-desc,
+  .cru-courses__title,
+  .crucible-message-card__title
+) {
+  color: var(--crucible-text-strong) !important;
+}
+
+[data-bs-theme="dark"] :is(
+  .cru-comp-framework,
+  .cru-course-short,
+  .cru-activities__title,
+  .crucible-message-card__subtitle,
+  .crucible-message-card__copy,
+  .lp-empty,
+  .lp-no-competencies
+) {
   color: var(--crucible-text-muted) !important;
 }
 
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#1d4ed8"] {
+[data-bs-theme="dark"] :is(
+  .cru-course-link,
+  .cru-activity a
+) {
   color: var(--crucible-link) !important;
 }
 
-[data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#92400e"] {
-  color: #f3d88c !important;
+[data-bs-theme="dark"] :is(
+  .cru-course-link,
+  .cru-activity a
+):hover {
+  color: var(--crucible-link-hover) !important;
+}
+
+[data-bs-theme="dark"] .cru-course-plan-status {
+  border-color: #20491e !important;
+  background: #0b180a !important;
+  color: #8abf84 !important;
+}
+
+[data-bs-theme="dark"] :is(
+  .lp-template__enrol-button,
+  .crucible-message-card__icon
+) {
+  background: var(--bs-primary, #2f6db2) !important;
 }
 
 /* The learning-plan confirmation is a prominent success notice, not a badge. */
-[data-bs-theme="dark"] .crucible-success-notice {
+[data-bs-theme="dark"] .crucible-template-view.crucible-success-notice {
   border-color: #2f7e42 !important;
   background: #102b17 !important;
   color: #d7f9dc !important;

--- a/styles.css
+++ b/styles.css
@@ -518,3 +518,21 @@
 [data-bs-theme="dark"] :is(.crucible-card, .crucible-template-view) [style*="color:#92400e"] {
   color: #f3d88c !important;
 }
+
+/* The learning-plan confirmation is a prominent success notice, not a badge. */
+[data-bs-theme="dark"] .crucible-success-notice {
+  border-color: #2f7e42 !important;
+  background: #102b17 !important;
+  color: #d7f9dc !important;
+}
+
+[data-bs-theme="dark"] .crucible-success-notice a {
+  border-color: #23713a !important;
+  background: #1a6f37 !important;
+  color: #fff !important;
+}
+
+[data-bs-theme="dark"] .crucible-success-notice a:hover,
+[data-bs-theme="dark"] .crucible-success-notice a:focus {
+  background: #218948 !important;
+}

--- a/templates/no_applications.mustache
+++ b/templates/no_applications.mustache
@@ -41,18 +41,18 @@
         "supportContact": "admin@example.com"
     }
 }}
-<div class="crucible-card crucible-template"
+<div class="crucible-card crucible-template crucible-message-card"
      style="margin:16px auto;border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 6px 16px rgba(2,6,23,.06);overflow:hidden;font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
 
   <!-- Header: icon + title (matches your template header) -->
-  <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
+  <div class="crucible-message-card__header" style="display:flex;justify-content:space-between;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
     <div style="display:flex;gap:10px;align-items:center;">
-      <div style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🧩</div>
+      <div class="crucible-message-card__icon" style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🧩</div>
       <div>
-        <div style="font-size:20px;font-weight:800;color:#1e3a8a;">
+        <div class="crucible-message-card__title" style="font-size:20px;font-weight:800;color:#1e3a8a;">
           {{#str}} noapps_heading, block_crucible {{/str}}
         </div>
-        <div style="font-size:13px;color:#475569;">
+        <div class="crucible-message-card__subtitle" style="font-size:13px;color:#475569;">
           {{#str}} hello_user_site_inline, block_crucible {{/str}} {{username}} — {{sitename}}
         </div>
       </div>
@@ -60,17 +60,16 @@
   </div>
 
   <!-- Body -->
-  <div style="padding:16px;background:#f8fafc;">
-    <div style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px;border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:20px;">
-      <img src="{{crucibleLogoAuth}}" alt="{{#str}} crucible_logo_alt, block_crucible {{/str}}"
+  <div class="crucible-message-card__body" style="padding:16px;background:#f8fafc;">
+    <div class="crucible-message-card__panel" style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px;border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:20px;">
+      <img class="crucible-message-card__logo" src="{{crucibleLogoAuth}}" alt="{{#str}} crucible_logo_alt, block_crucible {{/str}}"
            style="width:64px;height:64px;object-fit:contain;border-radius:12px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border:1px solid #e5e7eb;">
-      <h5 style="margin:0;font-weight:700;color:#0f172a;">
+      <h5 class="crucible-message-card__title" style="margin:0;font-weight:700;color:#0f172a;">
         {{#str}} app_config_problem_title, block_crucible {{/str}}
       </h5>
-      <p style="margin:0;color:#475569;">
+      <p class="crucible-message-card__copy" style="margin:0;color:#475569;">
         {{#str}} app_config_problem_body, block_crucible {{/str}}
       </p>
     </div>
   </div>
 </div>
-

--- a/templates/no_oauth.mustache
+++ b/templates/no_oauth.mustache
@@ -34,31 +34,31 @@
   @template block_crucible/oauth_error
 }}
 
-<div class="crucible-card crucible-oauth"
+<div class="crucible-card crucible-oauth crucible-message-card"
      style="margin:16px auto;border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 6px 16px rgba(2,6,23,.06);overflow:hidden;font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
 
   <!-- Header (matches other Crucible cards) -->
-  <div style="display:flex;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
-    <div style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🧩</div>
+  <div class="crucible-message-card__header" style="display:flex;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
+    <div class="crucible-message-card__icon" style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🧩</div>
     <div>
-      <div style="font-size:18px;font-weight:800;color:#1e3a8a;">
+      <div class="crucible-message-card__title" style="font-size:18px;font-weight:800;color:#1e3a8a;">
         {{#str}} oauth_error_heading, block_crucible {{/str}}
       </div>
-      <div style="font-size:13px;color:#475569;">
+      <div class="crucible-message-card__subtitle" style="font-size:13px;color:#475569;">
         {{#str}} oauth_error_subtitle, block_crucible {{/str}}
       </div>
     </div>
   </div>
 
   <!-- Body -->
-  <div style="padding:16px;background:#f8fafc;">
-    <div style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px;border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:20px;">
-      <img src="{{crucibleLogoAuth}}" alt="{{#str}} oauth_logo_alt, block_crucible {{/str}}"
+  <div class="crucible-message-card__body" style="padding:16px;background:#f8fafc;">
+    <div class="crucible-message-card__panel" style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px;border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:20px;">
+      <img class="crucible-message-card__logo" src="{{crucibleLogoAuth}}" alt="{{#str}} oauth_logo_alt, block_crucible {{/str}}"
            style="width:64px;height:64px;object-fit:contain;border-radius:12px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border:1px solid #e5e7eb;">
-      <h5 style="margin:0;font-weight:700;color:#0f172a;">
+      <h5 class="crucible-message-card__title" style="margin:0;font-weight:700;color:#0f172a;">
         {{#str}} oauth_error_title, block_crucible {{/str}}
       </h5>
-      <p style="margin:0;color:#475569;">
+      <p class="crucible-message-card__copy" style="margin:0;color:#475569;">
         {{#str}} oauth_error_body, block_crucible {{/str}}
       </p>
     </div>

--- a/templates/not_enabled.mustache
+++ b/templates/not_enabled.mustache
@@ -34,31 +34,31 @@
   @template block_crucible/not_enabled
 }}
 
-<div class="crucible-card crucible-notenabled"
+<div class="crucible-card crucible-notenabled crucible-message-card"
      style="margin:16px auto;border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 6px 16px rgba(2,6,23,.06);overflow:hidden;font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
 
   <!-- Header -->
-  <div style="display:flex;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
-    <div style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🧩</div>
+  <div class="crucible-message-card__header" style="display:flex;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
+    <div class="crucible-message-card__icon" style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🧩</div>
     <div>
-      <div style="font-size:18px;font-weight:800;color:#1e3a8a;">
+      <div class="crucible-message-card__title" style="font-size:18px;font-weight:800;color:#1e3a8a;">
         {{#str}} notenabled_heading, block_crucible {{/str}}
       </div>
-      <div style="font-size:13px;color:#475569;">
+      <div class="crucible-message-card__subtitle" style="font-size:13px;color:#475569;">
         {{#str}} notenabled_subtitle, block_crucible {{/str}}
       </div>
     </div>
   </div>
 
   <!-- Body -->
-  <div style="padding:16px;background:#f8fafc;">
-    <div style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px;border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:20px;">
-      <img src="{{crucibleLogoAuth}}" alt="{{#str}} notenabled_logo_alt, block_crucible {{/str}}"
+  <div class="crucible-message-card__body" style="padding:16px;background:#f8fafc;">
+    <div class="crucible-message-card__panel" style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px;border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:20px;">
+      <img class="crucible-message-card__logo" src="{{crucibleLogoAuth}}" alt="{{#str}} notenabled_logo_alt, block_crucible {{/str}}"
            style="width:64px;height:64px;object-fit:contain;border-radius:12px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border:1px solid #e5e7eb;">
-      <h5 style="margin:0;font-weight:700;color:#0f172a;">
+      <h5 class="crucible-message-card__title" style="margin:0;font-weight:700;color:#0f172a;">
         {{#str}} notenabled_title, block_crucible {{/str}}
       </h5>
-      <p style="margin:0;color:#475569;">
+      <p class="crucible-message-card__copy" style="margin:0;color:#475569;">
         {{#str}} notenabled_body, block_crucible {{/str}}
       </p>
     </div>

--- a/templates/template_view.mustache
+++ b/templates/template_view.mustache
@@ -1,5 +1,5 @@
 <!-- Search toolbar-->
-<div class="lp-toolbar"
+<div class="lp-toolbar crucible-template-view"
       style="display:flex;justify-content:flex-end;gap:8px;align-items:center;padding:12px 16px;background:#fff;">
   <label style="position:relative;display:block;flex:0 0 350px;max-width:350px;min-width:220px;">
     <input type="text" class="lp-search"
@@ -15,7 +15,7 @@
 </div>
 
 {{#hasplan}}
-  <div style="margin:12px 0;border:1px solid #bbf7d0;background:#dcfce7;color:#166534;border-radius:12px;padding:10px 12px;display:flex;justify-content:space-between;gap:12px;align-items:center;">
+  <div class="crucible-template-view" style="margin:12px 0;border:1px solid #bbf7d0;background:#dcfce7;color:#166534;border-radius:12px;padding:10px 12px;display:flex;justify-content:space-between;gap:12px;align-items:center;">
     <div style="font-weight:700;">{{#str}} youalreadyhavethisplan, block_crucible {{/str}}</div>
     <a href="{{planurl}}" style="padding:8px 12px;border:1px solid #166534;background:#166534;color:#fff;border-radius:10px;font-weight:700;text-decoration:none;">
       {{#str}} openmyplan, block_crucible {{/str}}
@@ -163,4 +163,3 @@ require(['block_crucible/search'], function(search) {
   search.init({ root: '.lp-template', toolbar: '.lp-toolbar' });
 });
 {{/js}}
-

--- a/templates/template_view.mustache
+++ b/templates/template_view.mustache
@@ -15,7 +15,7 @@
 </div>
 
 {{#hasplan}}
-  <div class="crucible-template-view" style="margin:12px 0;border:1px solid #bbf7d0;background:#dcfce7;color:#166534;border-radius:12px;padding:10px 12px;display:flex;justify-content:space-between;gap:12px;align-items:center;">
+  <div class="crucible-template-view crucible-success-notice" style="margin:12px 0;border:1px solid #bbf7d0;background:#dcfce7;color:#166534;border-radius:12px;padding:10px 12px;display:flex;justify-content:space-between;gap:12px;align-items:center;">
     <div style="font-weight:700;">{{#str}} youalreadyhavethisplan, block_crucible {{/str}}</div>
     <a href="{{planurl}}" style="padding:8px 12px;border:1px solid #166534;background:#166534;color:#fff;border-radius:10px;font-weight:700;text-decoration:none;">
       {{#str}} openmyplan, block_crucible {{/str}}

--- a/templates/template_view.mustache
+++ b/templates/template_view.mustache
@@ -25,18 +25,18 @@
 
 <div class="crucible-card crucible-template lp-template"
      style="margin:16px auto;border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 6px 16px rgba(2,6,23,.06);overflow:hidden;font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
-  <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
+  <div class="lp-template__header" style="display:flex;justify-content:space-between;gap:12px;align-items:center;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
     <div style="display:flex;gap:10px;align-items:center;">
       <div style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">📘</div>
       <div>
-        <div style="font-size:20px;font-weight:800;color:#1e3a8a;">{{shortname}}</div>
+        <div class="lp-template__title" style="font-size:20px;font-weight:800;color:#1e3a8a;">{{shortname}}</div>
       </div>
     </div>
 
     <div style="display:flex;gap:8px;align-items:center;min-width:280px;max-width:420px;flex:1;justify-content:flex-end;">
       {{#canselfenrol}}
         <form method="post" action="{{selfenrolurl}}" style="margin:0;">
-          <button type="submit"
+          <button type="submit" class="lp-template__enrol-button"
                   style="padding:10px 14px;border:1px solid #2563eb;background:#2563eb;color:#fff;border-radius:10px;font-weight:700;cursor:pointer;">
             {{#str}} addtomylearningplans, block_crucible {{/str}}
           </button>
@@ -46,13 +46,13 @@
   </div>
 
   <!-- Body -->
-  <div style="padding:16px;background:#fff;">
+  <div class="lp-template__body" style="padding:16px;background:#fff;">
     {{#description}}
-      <div style="font-size:15px;color:#0f172a;margin-bottom:16px;">{{{description}}}</div>
+      <div class="lp-template__description" style="font-size:15px;color:#0f172a;margin-bottom:16px;">{{{description}}}</div>
     {{/description}}
 
     {{#hascomps}}
-      <div style="font-size:16px;font-weight:800;color:#0f172a;margin:8px 0 10px;">
+      <div class="lp-template__section-title" style="font-size:16px;font-weight:800;color:#0f172a;margin:8px 0 10px;">
         {{#str}} competencies, block_crucible {{/str}}
       </div>
 
@@ -66,8 +66,8 @@
           <details class="cru-group"
                    data-group-name="{{groupname}}"
                    style="border:1px solid #e5e7eb;border-radius:12px;background:#fff;overflow:hidden;">
-            <summary style="display:flex;justify-content:space-between;align-items:center;gap:10px;padding:10px 12px;background:#f8fafc;cursor:pointer;">
-              <div style="font-weight:800;color:#0f172a;font-size:15px;line-height:1.3;">
+            <summary class="cru-group__summary" style="display:flex;justify-content:space-between;align-items:center;gap:10px;padding:10px 12px;background:#f8fafc;cursor:pointer;">
+              <div class="cru-group__name" style="font-weight:800;color:#0f172a;font-size:15px;line-height:1.3;">
                 {{groupname}}
               </div>
               <span class="cru-group-count" style="font-size:12px;background:#eef2ff;color:#1e3a8a;border:1px solid #dbeafe;border-radius:999px;padding:2px 8px;white-space:nowrap;">
@@ -75,14 +75,14 @@
               </span>
             </summary>
 
-            <div style="padding:12px;display:flex;flex-direction:column;gap:12px;background:#fff;">
+            <div class="cru-group__content" style="padding:12px;display:flex;flex-direction:column;gap:12px;background:#fff;">
               {{#items}}
                 <div class="cru-comp"
                          data-comp-name="{{shortname}}"
                          {{#framework}}data-comp-framework="{{framework}}"{{/framework}}
                          {{#idnumber}}data-comp-id="{{idnumber}}"{{/idnumber}}
                          style="border:1px solid #e5e7eb;border-radius:12px;background:#f8fafc;">
-                  <summary style="display:flex;justify-content:space-between;align-items:start;gap:10px;padding:12px;cursor:pointer;">
+                  <summary class="cru-comp__summary" style="display:flex;justify-content:space-between;align-items:start;gap:10px;padding:12px;cursor:pointer;">
                     <div>
                       <div class="cru-comp-title" style="font-weight:800;color:#0f172a;font-size:16px;line-height:1.3;">{{shortname}}</div>
                       {{#framework}}
@@ -102,7 +102,7 @@
 
                   {{#hascourses}}
                     <div class="cru-courses" style="margin:0 12px 12px 12px;">
-                      <div style="font-weight:700;color:#0f172a;margin-bottom:6px;">
+                      <div class="cru-courses__title" style="font-weight:700;color:#0f172a;margin-bottom:6px;">
                         {{#str}} courses, block_crucible {{/str}}
                       </div>
                       <ul class="cru-course-list" style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:10px;">
@@ -118,14 +118,14 @@
                                   <span class="cru-course-short" style="color:#64748b;"> ({{shortname}})</span>
                                 {{/shortname}}
                               </div>
-                              <span style="font-size:12px;background:#dcfce7;color:#166534;border:1px solid #bbf7d0;border-radius:999px;padding:2px 8px;white-space:nowrap;display:inline-flex;gap:6px;align-items:center;">
+                              <span class="cru-course-plan-status" style="font-size:12px;background:#dcfce7;color:#166534;border:1px solid #bbf7d0;border-radius:999px;padding:2px 8px;white-space:nowrap;display:inline-flex;gap:6px;align-items:center;">
                                 📚 {{#str}} course, block_crucible {{/str}}
                               </span>
                             </div>
 
                             {{#hasacts}}
                               <div class="cru-activities" style="border-top:1px solid #f1f5f9;padding:10px 12px;background:#f8fafc;border-bottom-left-radius:12px;border-bottom-right-radius:12px;">
-                                <div style="font-size:12px;color:#64748b;margin-bottom:6px;display:flex;align-items:center;gap:6px;">
+                                <div class="cru-activities__title" style="font-size:12px;color:#64748b;margin-bottom:6px;display:flex;align-items:center;gap:6px;">
                                   ▶️ {{#str}} mappedactivities, block_crucible {{/str}} {{#actcount}}({{actcount}}){{/actcount}}
                                 </div>
                                 <ul class="cru-activity-list" style="list-style:none;margin:0;padding:0 0 0 2px;display:flex;flex-direction:column;gap:4px;">
@@ -151,7 +151,7 @@
     {{/hascomps}}
 
     {{^hascomps}}
-      <div style="border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:16px;color:#475569;text-align:center;">
+      <div class="lp-no-competencies" style="border:1px dashed #cbd5e1;border-radius:12px;background:#fff;padding:16px;color:#475569;text-align:center;">
         {{#str}} nocompetenciesintemplate, block_crucible {{/str}}
       </div>
     {{/hascomps}}

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026051500;
+$plugin->version = 2026083100;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026083100;
+$plugin->version = 2026083101;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
## Summary
- add scoped Boost Dark styles for Crucible block cards, applications, competency lists, and legacy inline template colors
- make the template search toolbar and learning-plan notice dark-theme aware
- bump the plugin version for Moodle cache invalidation

## Verification
- tested real local Dashboard block instances in dark mode
- tested the local competency detail page with 
- checked PHP syntax and Git whitespace