### PR TITLE
fix: honor per-instance header setting

### DIFF
--- a/block_crucible.php
+++ b/block_crucible.php
@@ -81,8 +81,8 @@ class block_crucible extends block_base
      * @return bool
      */
     public function hide_header() {
-        if (isset($this->config) && isset($this->config->config_showheader)) {
-            $show = (bool)$this->config->config_showheader;
+        if (isset($this->config) && isset($this->config->showheader)) {
+            $show = (bool)$this->config->showheader;
         } else {
             // Fallback to site default, or show if no setting yet.
             $show = (bool)get_config('block_crucible', 'showheader_default');

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026083101;
+$plugin->version = 2026090200;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
## Summary
- read the persisted showheader block setting when determining header visibility
- bump the plugin version for Moodle upgrade detection

## Validation
- php lint passed for block_crucible.php and version.php