### PR TITLE
fix: improve competency detail page behavior

### DIFF
--- a/competency.php
+++ b/competency.php
@@ -94,3 +94,5 @@ if ($fwid) {
     echo $OUTPUT->footer();
     exit;
 }
+
+throw new moodle_exception('missingcompetencyparams', 'block_crucible');

--- a/competency.php
+++ b/competency.php
@@ -31,6 +31,7 @@ $framework = optional_param('framework', '', PARAM_RAW_TRIMMED);
 require_login();
 $context = context_system::instance();
 $PAGE->set_context($context);
+$PAGE->set_url(new moodle_url('/blocks/crucible/competency.php'));
 
 $svc = new \block_crucible\competencies();
 
@@ -38,11 +39,16 @@ $svc = new \block_crucible\competencies();
 $frameworkid = null;
 if ($framework !== '') {
     $fw = \core_competency\competency_framework::get_record(['shortname' => $framework]);
-    if ($fw) {
-        $frameworkid = (int)$fw->get('id');
+    if (!$fw) {
+        throw new moodle_exception('invalidcompetencyframework', 'block_crucible');
     }
+    $frameworkid = (int)$fw->get('id');
 } else if ($fwid > 0) {
-    $frameworkid = $fwid;
+    $fw = \core_competency\competency_framework::get_record(['id' => $fwid]);
+    if (!$fw) {
+        throw new moodle_exception('invalidcompetencyframework', 'block_crucible');
+    }
+    $frameworkid = (int)$fw->get('id');
 }
 
 if ($idnumber) {
@@ -74,9 +80,9 @@ if ($idnumber) {
     exit;
 }
 
-if ($fwid) {
-    $PAGE->set_url(new moodle_url('/blocks/crucible/competency.php', ['fwid' => $fwid]));
-    $data = $svc->get_unmapped_for_framework($fwid);
+if ($frameworkid !== null) {
+    $PAGE->set_url(new moodle_url('/blocks/crucible/competency.php', ['fwid' => $frameworkid]));
+    $data = $svc->get_unmapped_for_framework($frameworkid);
 
     $PAGE->set_title(get_string('unmapped_for_framework_title', 'block_crucible', $data->framework));
     $PAGE->set_heading(format_string($SITE->fullname));

--- a/lang/en/block_crucible.php
+++ b/lang/en/block_crucible.php
@@ -190,8 +190,6 @@ $string['learningplantitle'] = 'Learning plan';
 $string['blockheading'] = 'Suggested Learning Plans';
 $string['competencies'] = 'Competencies';
 $string['nocompetenciesintemplate'] = 'This learning plan has no competencies yet.';
-$string['courses'] = 'Courses';
-$string['activities'] = 'activities';
 $string['addtomylearningplans'] = 'Enroll in this learning plan';
 $string['planselfenrolled'] = 'Learning plan added to your plans.';
 $string['plandalreadyexists'] = 'You already have this learning plan.';
@@ -244,6 +242,7 @@ $string['col_activities']        = 'Activities';
 $string['nocompsmapped']         = 'No competencies are currently mapped to courses or activities.';
 $string['activitiesandresources'] = 'Activities and resources';
 $string['activities']             = 'Activities';
+$string['activitiescount']        = 'activities';
 $string['courses']                = 'Courses';
 $string['category']               = 'Category';
 $string['nocoursesmapped']        = 'No courses are mapped to this competency.';
@@ -261,6 +260,7 @@ $string['configenableorgrolesync'] = 'When enabled, automatically assigns organi
 $string['learning_plan'] = 'Learning Plan';
 $string['framework'] = 'Framework';
 $string['missingcompetencyparams'] = 'Choose a competency by providing an ID number or framework ID.';
+$string['invalidcompetencyframework'] = 'The requested competency framework could not be found.';
 
 // Reports
 $string['reportnotsetmessage'] = 'No report is available for you right now.';

--- a/lang/en/block_crucible.php
+++ b/lang/en/block_crucible.php
@@ -260,6 +260,7 @@ $string['enableorgrolesync'] = 'Enable Organization Role Sync';
 $string['configenableorgrolesync'] = 'When enabled, automatically assigns organization-scoped roles to users based on their Keycloak group membership. This runs as a scheduled task hourly and also on user login.';
 $string['learning_plan'] = 'Learning Plan';
 $string['framework'] = 'Framework';
+$string['missingcompetencyparams'] = 'Choose a competency by providing an ID number or framework ID.';
 
 // Reports
 $string['reportnotsetmessage'] = 'No report is available for you right now.';

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,96 @@
 
 .crucible-card__body { padding: 12px; background:#f8fafc; }
 
+.crucible-competency-detail__idnumber {
+  margin-left: 8px;
+  color: #64748b;
+}
+
+.crucible-competency-panel {
+  margin-bottom: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.crucible-competency-panel:last-child {
+  margin-bottom: 0;
+}
+
+.crucible-competency-panel__heading {
+  margin: 0;
+  padding: 10px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  color: #0f172a;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.crucible-competency-panel__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.crucible-competency-panel__item {
+  padding: 12px;
+  border-top: 1px solid #f1f5f9;
+}
+
+.crucible-competency-panel__heading + .crucible-competency-panel__item,
+.crucible-competency-panel__heading + .crucible-competency-panel__list .crucible-competency-panel__item:first-child {
+  border-top: 0;
+}
+
+.crucible-competency-panel__link {
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.crucible-competency-panel__link:hover {
+  text-decoration: underline;
+}
+
+.crucible-competency-panel__meta,
+.crucible-competency-panel__empty {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.crucible-competency-panel__meta--spaced {
+  margin-top: 2px;
+}
+
+.crucible-competency-panel__empty {
+  margin: 0;
+  padding: 12px;
+}
+
+.crucible-competency-panel__course {
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+
+.crucible-competency-panel__course a {
+  color: #0f172a;
+  text-decoration: none;
+}
+
+.crucible-competency-panel__activities {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.crucible-competency-panel__activity {
+  margin: 6px 0;
+}
+
+.crucible-competency-panel__activity a {
+  text-decoration: none;
+}
+
 .comp-table {
   border: 1px solid #e5e7eb;
   border-radius: 12px;
@@ -357,12 +447,48 @@
 
 [data-bs-theme="dark"] :is(
   .crucible-card__subtitle,
+  .crucible-competency-detail__idnumber,
+  .crucible-competency-panel__meta,
+  .crucible-competency-panel__empty,
   .comp-meta,
   .notice--empty,
   .role-line--ok,
   .app-card__desc
 ) {
   color: var(--crucible-text-muted);
+}
+
+[data-bs-theme="dark"] .crucible-competency-panel {
+  border-color: var(--crucible-border);
+  background: var(--crucible-surface);
+  color: var(--crucible-text);
+}
+
+[data-bs-theme="dark"] .crucible-competency-panel__heading {
+  border-color: var(--crucible-border);
+  color: var(--crucible-text-strong);
+}
+
+[data-bs-theme="dark"] .crucible-competency-panel__item {
+  border-color: var(--crucible-border);
+}
+
+[data-bs-theme="dark"] :is(
+  .crucible-competency-panel__link,
+  .crucible-competency-panel__activity a
+) {
+  color: var(--crucible-link);
+}
+
+[data-bs-theme="dark"] :is(
+  .crucible-competency-panel__link,
+  .crucible-competency-panel__activity a
+):hover {
+  color: var(--crucible-link-hover);
+}
+
+[data-bs-theme="dark"] .crucible-competency-panel__course a {
+  color: var(--crucible-text-strong);
 }
 
 [data-bs-theme="dark"] :is(

--- a/templates/competency_view.mustache
+++ b/templates/competency_view.mustache
@@ -2,7 +2,7 @@
   <div class="crucible-card__header">
     <div class="crucible-card__icon">🏷️</div>
     <div class="crucible-card__titlewrap">
-      <div class="crucible-card__title">{{cardtitle}}</div>
+      <div class="crucible-card__title">{{{cardtitle}}}</div>
       <div class="crucible-card__subtitle">
         {{#framework}}<strong>{{framework}}</strong>{{/framework}}
         {{#idnumber}}<span class="crucible-competency-detail__idnumber">{{idnumber}}</span>{{/idnumber}}
@@ -17,9 +17,9 @@
         <ul class="crucible-competency-panel__list">
           {{#courses}}
             <li class="crucible-competency-panel__item">
-              <a class="crucible-competency-panel__link" href="{{url}}">{{fullname}}</a>
-              {{#category}}<div class="crucible-competency-panel__meta">{{#str}} category, block_crucible {{/str}}: {{.}}</div>{{/category}}
-              {{#actcount}}<div class="crucible-competency-panel__meta crucible-competency-panel__meta--spaced">{{actcount}} {{#str}} activities, block_crucible {{/str}}</div>{{/actcount}}
+              <a class="crucible-competency-panel__link" href="{{url}}">{{{fullname}}}</a>
+              {{#category}}<div class="crucible-competency-panel__meta">{{#str}} category, block_crucible {{/str}}: {{{.}}}</div>{{/category}}
+              {{#actcount}}<div class="crucible-competency-panel__meta crucible-competency-panel__meta--spaced">{{actcount}} {{#str}} activitiescount, block_crucible {{/str}}</div>{{/actcount}}
             </li>
           {{/courses}}
         </ul>
@@ -32,10 +32,10 @@
       {{#hasactivities}}
         {{#bycourse}}
           <div class="crucible-competency-panel__item">
-            <div class="crucible-competency-panel__course"><a href="{{courseurl}}">{{coursename}}</a></div>
+            <div class="crucible-competency-panel__course"><a href="{{courseurl}}">{{{coursename}}}</a></div>
             <ul class="crucible-competency-panel__activities">
               {{#activities}}
-                <li class="crucible-competency-panel__activity"><a href="{{url}}">{{name}}</a></li>
+                <li class="crucible-competency-panel__activity"><a href="{{url}}">{{{name}}}</a></li>
               {{/activities}}
             </ul>
           </div>

--- a/templates/competency_view.mustache
+++ b/templates/competency_view.mustache
@@ -1,47 +1,47 @@
-<div class="crucible-card" style="margin:16px auto;border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 6px 16px rgba(2,6,23,.06);overflow:hidden;font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
-  <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;background:linear-gradient(135deg,#e0f2fe,#f8fafc);border-bottom:1px solid #dbeafe;">
-    <div style="width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,#60a5fa,#2563eb);display:flex;align-items:center;justify-content:center;color:#fff;">🏷️</div>
-    <div>
-      <div style="font-size:20px;font-weight:800;color:#1e3a8a;">{{cardtitle}}</div>
-      <div style="font-size:12px;color:#475569;">
+<div class="crucible-card crucible-competency-detail">
+  <div class="crucible-card__header">
+    <div class="crucible-card__icon">🏷️</div>
+    <div class="crucible-card__titlewrap">
+      <div class="crucible-card__title">{{cardtitle}}</div>
+      <div class="crucible-card__subtitle">
         {{#framework}}<strong>{{framework}}</strong>{{/framework}}
-        {{#idnumber}}<span style="margin-left:8px;color:#64748b;">{{idnumber}}</span>{{/idnumber}}
+        {{#idnumber}}<span class="crucible-competency-detail__idnumber">{{idnumber}}</span>{{/idnumber}}
       </div>
     </div>
   </div>
 
-  <div style="padding:12px;background:#f8fafc;">
-    <div style="border:1px solid #e5e7eb;border-radius:12px;background:#fff;overflow:hidden;margin-bottom:12px;">
-      <div style="padding:10px 12px;border-bottom:1px solid #e5e7eb;font-weight:800;">{{#str}} courses, block_crucible {{/str}}</div>
+  <div class="crucible-card__body">
+    <section class="crucible-competency-panel">
+      <h2 class="crucible-competency-panel__heading">{{#str}} courses, block_crucible {{/str}}</h2>
       {{#hascourses}}
-        <ul style="list-style:none;margin:0;padding:0;">
+        <ul class="crucible-competency-panel__list">
           {{#courses}}
-            <li style="padding:12px 12px;border-top:1px solid #f1f5f9;">
-              <a href="{{url}}" style="font-weight:700;text-decoration:none;color:#1d4ed8;">{{fullname}}</a>
-              {{#category}}<div style="font-size:12px;color:#64748b;">{{#str}} category, block_crucible {{/str}}: {{.}}</div>{{/category}}
-              {{#actcount}}<div style="font-size:12px;color:#64748b;margin-top:2px;">{{actcount}} {{#str}} activities, block_crucible {{/str}}</div>{{/actcount}}
+            <li class="crucible-competency-panel__item">
+              <a class="crucible-competency-panel__link" href="{{url}}">{{fullname}}</a>
+              {{#category}}<div class="crucible-competency-panel__meta">{{#str}} category, block_crucible {{/str}}: {{.}}</div>{{/category}}
+              {{#actcount}}<div class="crucible-competency-panel__meta crucible-competency-panel__meta--spaced">{{actcount}} {{#str}} activities, block_crucible {{/str}}</div>{{/actcount}}
             </li>
           {{/courses}}
         </ul>
       {{/hascourses}}
-      {{^hascourses}}<div style="padding:12px;color:#64748b;">{{#str}} nocoursesmapped, block_crucible {{/str}}</div>{{/hascourses}}
-    </div>
+      {{^hascourses}}<p class="crucible-competency-panel__empty">{{#str}} nocoursesmapped, block_crucible {{/str}}</p>{{/hascourses}}
+    </section>
 
-    <div style="border:1px solid #e5e7eb;border-radius:12px;background:#fff;overflow:hidden;">
-      <div style="padding:10px 12px;border-bottom:1px solid #e5e7eb;font-weight:800;">{{#str}} activitiesandresources, block_crucible {{/str}}</div>
+    <section class="crucible-competency-panel">
+      <h2 class="crucible-competency-panel__heading">{{#str}} activitiesandresources, block_crucible {{/str}}</h2>
       {{#hasactivities}}
         {{#bycourse}}
-          <div style="padding:12px 12px;border-top:1px solid #f1f5f9;">
-            <div style="font-weight:700;margin-bottom:6px;"><a href="{{courseurl}}" style="text-decoration:none;color:#0f172a;">{{coursename}}</a></div>
-            <ul style="margin:0;padding-left:18px;">
+          <div class="crucible-competency-panel__item">
+            <div class="crucible-competency-panel__course"><a href="{{courseurl}}">{{coursename}}</a></div>
+            <ul class="crucible-competency-panel__activities">
               {{#activities}}
-                <li style="margin:6px 0;"><a href="{{url}}" style="text-decoration:none;">{{name}}</a></li>
+                <li class="crucible-competency-panel__activity"><a href="{{url}}">{{name}}</a></li>
               {{/activities}}
             </ul>
           </div>
         {{/bycourse}}
       {{/hasactivities}}
-      {{^hasactivities}}<div style="padding:12px;color:#64748b;">{{#str}} noactivitiesmapped, block_crucible {{/str}}</div>{{/hasactivities}}
-    </div>
+      {{^hasactivities}}<p class="crucible-competency-panel__empty">{{#str}} noactivitiesmapped, block_crucible {{/str}}</p>{{/hasactivities}}
+    </section>
   </div>
 </div>

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026090200;
+$plugin->version = 2026090300;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
## Summary
- render a localized Moodle error when the competency route has no identifier
- replace inline competency-detail colors with semantic classes and dark-theme styles
- bump the plugin version

## Validation
- `php -l competency.php`
- `php -l version.php`
- `git diff --check`
- manually verified the local detail route renders correctly in dark mode