### PR TITLE
fix: honor selected framework when opening a learning plan

### DIFF
--- a/template.php
+++ b/template.php
@@ -85,7 +85,16 @@ $data->frameworkshortname = $fwname;
 
 if ($plan = $svc->get_user_plan_from_template($tid, $USER->id)) {
     $data->hasplan = true;
-    $data->planurl = (new moodle_url('/admin/tool/lp/plan.php', ['id' => $plan->id]))->out(false);
+    // When a framework filter is active, keep "Open my plan" inside the block's
+    // framework-scoped view. The core plan page (/admin/tool/lp/plan.php) mirrors
+    // the whole template and shows every framework's competencies, which ignores
+    // the framework chosen in the block settings. Only link to the core plan when
+    // no framework filter is applied.
+    if ($fwid > 0) {
+        $data->planurl = (new moodle_url('/blocks/crucible/template.php', ['id' => $tid, 'fw' => $fwshort]))->out(false);
+    } else {
+        $data->planurl = (new moodle_url('/admin/tool/lp/plan.php', ['id' => $plan->id]))->out(false);
+    }
     $data->canselfenrol = false;
 } else {
     $data->hasplan = false;

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM24-1176
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026090300;
+$plugin->version = 2026090800;
 $plugin->requires  = 2025041400;
 $plugin->component = 'block_crucible';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
When a framework is selected in the block settings, the learning-plan template view already filtered competencies to that framework, but the **"Open my plan"** link pointed at the core plan page (`/admin/tool/lp/plan.php`). That page mirrors the whole template and shows every framework’s competencies, so a template spanning multiple frameworks (e.g. NICE, DCWF, MITRE ATT&CK) surfaced **all** of them despite a single framework being selected.

## Change
`template.php`: when a framework filter is active, route "Open my plan" to the block’s framework-scoped template view; only link to the core plan page when no framework is selected.

## Notes
- This is a **view-lens** fix. A multi-framework template legitimately produces a multi-framework plan, so the core plan page continuing to span frameworks is by design — this keeps the *block’s* "my plan" action consistent with the framework the user is viewing.
- Resolves the duplicate/both-frameworks symptom reported in **MoodleMDL-138** (self-enrol / learning-plan framework leak).

## Testing
- Seeded NICE + DCWF + MITRE ATT&CK frameworks all sharing competency idnumber `T1005` in one template; verified the filtered view returns only the selected framework’s competency and the unfiltered view returns all three.
- Verified the `planurl` branch: framework selected → block view; no framework → core plan page.
- `php -l` and `phpcs --standard=moodle` clean.